### PR TITLE
Allow player rig component to be nested inside rig prefab

### DIFF
--- a/Runtime/Definitions/PlayerServiceProfile.cs
+++ b/Runtime/Definitions/PlayerServiceProfile.cs
@@ -30,7 +30,7 @@ namespace RealityToolkit.Player.Definitions
         /// </summary>
         public bool ResetPlayerToOrigin => resetPlayerToOrigin;
 
-        [SerializeField, Tooltip("The player rig prefab used by this service module."), Prefab(typeof(IPlayerRig))]
+        [SerializeField, Tooltip("The player rig prefab used by this service module."), Prefab]
         private GameObject rigPrefab = null;
 
         /// <summary>

--- a/Runtime/PlayerService.cs
+++ b/Runtime/PlayerService.cs
@@ -121,15 +121,15 @@ namespace RealityToolkit.Player
 #if UNITY_EDITOR
                         if (Application.isPlaying)
                         {
-                            PlayerRig = UnityEngine.Object.Instantiate(rigPrefab).GetComponent<IPlayerRig>();
+                            PlayerRig = Object.Instantiate(rigPrefab).GetComponentInChildren<IPlayerRig>(true);
                         }
                         else
                         {
                             var go = UnityEditor.PrefabUtility.InstantiatePrefab(rigPrefab) as GameObject;
-                            PlayerRig = go.GetComponent<IPlayerRig>();
+                            PlayerRig = go.GetComponentInChildren<IPlayerRig>(true);
                         }
 #else
-                    PlayerRig = UnityEngine.Object.Instantiate(rigPrefab).GetComponent<IPlayerRig>();
+                        PlayerRig = Object.Instantiate(rigPrefab).GetComponentInChildren<IPlayerRig>(true);
 #endif
                     }
                     else


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

Upon further review and actual real world project need I have decided to drop the requirement that the `IPlayerRIg` component must sit at the root of the assigned player rig prefab in the `PlayerServiceProfile`.

This is specifically important and useful when developers have specific rig requirements, where the rig is e.g. wrapped in another GameObject.

The player service was modified to look for the `IPlayerRig` using GetComponentInChildren instead of GetComponent. It will also include inacive game objects, since developers might decide to have their rig disabled initially.