### PR TITLE
Add PlayerTrigger component

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,24 +13,50 @@ The player module contains services, utilities and prefabs around the user/playe
 
 Make sure to always use the same source for all toolkit modules. Avoid using different installation sources within the same project. We provide the following ways to install Reality Toolkit modules:
 
-### Method 1: Using Package Manager for git users
+### Method 1: OpenUPM CLI
 
-1. Open the Package Manager using the Window menu -> Package Manager
-
-2. Inside the Package Manager, click on the "+" button on the top left and select "Add package from git URL..."
-
-3. Input the following URL: https://github.com/realitycollective/com.realitytoolkit.player.git and click "Add".
-
-### Method 2: OpenUPM
+This method requires the [OpenUPM CLI](https://openupm.com/#get-started-with-cli-optional) to be installed on your computer.
 
 ```text
     openupm add com.realitytoolkit.player
 ```
 
-### Method 3: Unity Asset Store
+### Method 2: OpenUPM Scoped Registry
 
-This option will be available soon.
+If you do not wish to use the [OpenUPM CLI](https://openupm.com/#get-started-with-cli-optional) you can also manually add the OpenUPM registry to your project and browse all available toolkit packages.
+
+1. Open the [Project Settings](https://docs.unity3d.com/Manual/comp-ManagerGroup.html) window.
+   
+2. Select the **Package Manager** settings category to the left.
+   
+3. Add a new scoped registry
+   1. Name: **OpenUPM**
+   2. URL: **https://package.openupm.com**
+   3. Scopes: **com.realitycollective** and **com.realitytoolkit**
+   4. Press **Save** 
+
+![Add Scoped Registry](https://github.com/realitycollective/realitycollective.logo/blob/main/RealityToolkit/ReadmeAssets/add-scoped-registry.png?raw=true)
+
+4. Open the [Package Manager](https://docs.unity3d.com/Manual/Packages.html) window.
+   
+5. In the top left packages filter dropdown select **My Registries**.
+   
+6. You'll now see all published toolkit packages listed for you to install.
+
+![Add Scoped Registry](https://github.com/realitycollective/realitycollective.logo/blob/main/RealityToolkit/ReadmeAssets/package-manager-registry.png?raw=true)
+
+### Method 3: Using Package Manager for git users
+
+1. Open the [Package Manager](https://docs.unity3d.com/Manual/Packages.html) through this menu: **Window -> Package Manager**.
+
+2. Inside the [Package Manager](https://docs.unity3d.com/Manual/Packages.html), click on the **+** button on the top left and select **Add package from git URL...**.
+
+3. Input the following URL: https://github.com/realitycollective/com.realitytoolkit.player.git and click **Add**.
+
+### Method 4: Unity Asset Store
+
+We are working on making the Reality Toolkit available via the Unity asset store and will share news, once available.
 
 ## Getting Started
 
-Check the ["Getting Started"](https://www.realitytoolkit.io/) documentation for the Reality Toolkit and to learn more about this module.
+Check the [Getting Started](https://www.realitytoolkit.io/) documentation for the Reality Toolkit and to learn more about this module.

--- a/Runtime/UX/PlayerTrigger.cs
+++ b/Runtime/UX/PlayerTrigger.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using RealityToolkit.Player.Rigs;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace RealityToolkit.Player.UX
+{
+    /// <summary>
+    /// A simple utility component that will raise events w
+    /// </summary>
+    [HelpURL("https://www.realitytoolkit.io/docs/category/player")]
+    [RequireComponent(typeof(Collider))]
+    public class PlayerTrigger : MonoBehaviour
+    {
+        [SerializeField, Tooltip("Raised, when the player enters the trigger zone.")]
+        private UnityEvent onPlayerEnter = null;
+
+        [Space, SerializeField, Tooltip("Raised, while the player is within the trigger zone.")]
+        private UnityEvent onPlayerStay = null;
+
+        [Space, SerializeField, Tooltip("Raised, when the player leaves the trigger zone.")]
+        private UnityEvent onPlayerExit = null;
+
+        /// <summary>
+        /// Raised, when the player enters the trigger zone.
+        /// </summary>
+        public UnityEvent OnPlayerEnter => onPlayerEnter;
+
+        /// <summary>
+        /// Raised, while the player is within the trigger zone.
+        /// </summary>
+        public UnityEvent OnPlayerStay => onPlayerStay;
+
+        /// <summary>
+        /// Raised, when the player leaves the trigger zone.
+        /// </summary>
+        public UnityEvent OnPlayerExit => onPlayerExit;
+
+        /// <summary>
+        /// See <see cref="MonoBehaviour"/>.
+        /// </summary>
+        private void OnTriggerEnter(Collider other)
+        {
+            if (!other.TryGetComponent<IPlayerRig>(out _))
+            {
+                return;
+            }
+
+            OnPlayerEnter?.Invoke();
+        }
+
+        /// <summary>
+        /// See <see cref="MonoBehaviour"/>.
+        /// </summary>
+        private void OnTriggerStay(Collider other)
+        {
+            if (!other.TryGetComponent<IPlayerRig>(out _))
+            {
+                return;
+            }
+
+            OnPlayerStay?.Invoke();
+        }
+
+        /// <summary>
+        /// See <see cref="MonoBehaviour"/>.
+        /// </summary>
+        private void OnTriggerExit(Collider other)
+        {
+            if (!other.TryGetComponent<IPlayerRig>(out _))
+            {
+                return;
+            }
+
+            OnPlayerExit?.Invoke();
+        }
+    }
+}

--- a/Runtime/UX/PlayerTrigger.cs
+++ b/Runtime/UX/PlayerTrigger.cs
@@ -8,7 +8,7 @@ using UnityEngine.Events;
 namespace RealityToolkit.Player.UX
 {
     /// <summary>
-    /// A simple utility component that will raise events w
+    /// A simple utility component that will raise events as the player enters, leaves or stays within a trigger zone.
     /// </summary>
     [HelpURL("https://www.realitytoolkit.io/docs/category/player")]
     [RequireComponent(typeof(Collider))]

--- a/Runtime/UX/PlayerTrigger.cs
+++ b/Runtime/UX/PlayerTrigger.cs
@@ -41,6 +41,19 @@ namespace RealityToolkit.Player.UX
         /// <summary>
         /// See <see cref="MonoBehaviour"/>.
         /// </summary>
+        private void Awake()
+        {
+            var collider = GetComponent<Collider>();
+            if (!collider.isTrigger)
+            {
+                collider.isTrigger = true;
+                Debug.LogWarning($"{nameof(PlayerTrigger)} requires the attached {nameof(Collider)} to be a trigger and has auto configured it.", this);
+            }
+        }
+
+        /// <summary>
+        /// See <see cref="MonoBehaviour"/>.
+        /// </summary>
         private void OnTriggerEnter(Collider other)
         {
             if (!other.TryGetComponent<IPlayerRig>(out _))

--- a/Runtime/UX/PlayerTrigger.cs.meta
+++ b/Runtime/UX/PlayerTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e37f611479aea84eb78691a447708db
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 08c0fd91bdca45afa09ec64323cf3848, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

Adds a new useful component `PlayerTrigger`, which will raise events as the player enters, leaves or stays within the trigger zone.
The component only requires a collider on the game object and will enforce it.

![image](https://github.com/realitycollective/com.realitytoolkit.player/assets/9565734/93e4eb15-bfc7-4152-a646-b3eee4c81482)

