### PR TITLE
Fix docs and improve out of bounds calculation

### DIFF
--- a/Assets~/Profiles/DefaultPlayerServiceProfile.asset
+++ b/Assets~/Profiles/DefaultPlayerServiceProfile.asset
@@ -33,7 +33,7 @@ MonoBehaviour:
       reference: a68682d3-3e9d-4d56-8a32-9805f58928f8
     name: Player Bounds Module
     priority: 1
-    profile: {fileID: 0}
+    profile: {fileID: 11400000, guid: 9fbf13d08b435e747b145c505b5b7896, type: 2}
     platformEntries:
       runtimePlatforms:
       - reference: 9869b29e-43bb-44cc-ae49-eb5c913263f9

--- a/Assets~/Profiles/PlayerBoundsModuleProfile.asset
+++ b/Assets~/Profiles/PlayerBoundsModuleProfile.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45845bc60a29897449c67c8bd5176eb6, type: 3}
+  m_Name: PlayerBoundsModuleProfile
+  m_EditorClassIdentifier: 
+  maxSeverityDistanceThreshold: 0.2

--- a/Assets~/Profiles/PlayerBoundsModuleProfile.asset.meta
+++ b/Assets~/Profiles/PlayerBoundsModuleProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9fbf13d08b435e747b145c505b5b7896
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets~/StandardAssets/Prefabs/XRPlayerController.prefab
+++ b/Assets~/StandardAssets/Prefabs/XRPlayerController.prefab
@@ -129,7 +129,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   sphereCollider: {fileID: 367572774002706352}
-  maxSeverityDistanceThreshold: 0.2
 --- !u!135 &367572774002706352
 SphereCollider:
   m_ObjectHideFlags: 0

--- a/Runtime/Bounds/IPlayerBoundsModule.cs
+++ b/Runtime/Bounds/IPlayerBoundsModule.cs
@@ -27,6 +27,16 @@ namespace RealityToolkit.Player.Bounds
     public interface IPlayerBoundsModule : IPlayerServiceModule
     {
         /// <summary>
+        /// If set, the player will be reset into bounds if out of bounds for a given period of time.
+        /// </summary>
+        bool AutoResetEnabled { get; set; }
+
+        /// <summary>
+        /// Duration in seconds tolerated out of bounds until the player is automatically reset into bounds.
+        /// </summary>
+        float AutoResetTimeout { get; set; }
+
+        /// <summary>
         /// Is the active <see cref="Rigs.IPlayerRig"/> currently considered out of bounds?
         /// </summary>
         bool IsPlayerOutOfBounds { get; }

--- a/Runtime/Bounds/IPlayerBoundsModule.cs
+++ b/Runtime/Bounds/IPlayerBoundsModule.cs
@@ -1,18 +1,23 @@
 ﻿// Copyright (c) Reality Collective. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using UnityEngine;
 
 namespace RealityToolkit.Player.Bounds
 {
     /// <summary>
-    /// Event delegate for handling the playerService out of bounds situation.
+    /// Event delegate for handling the player out of bounds situation.
     /// </summary>
     /// <param name="severity">A percentage in range <c>[0f, 1f]</c> specifying how far of bounds the player is. Where <c>1f</c> means the player
     /// is definitely going places it should not be at.</param>
     /// <param name="returnToBoundsDirection">A <see cref="Vector3"/> specifying the direction the player needs to take to return to into bounds.</param>
     public delegate void PlayerOutOfBoundsDelegate(float severity, Vector3 returnToBoundsDirection);
+
+    /// <summary>
+    /// Event delegate for handling the the player's return into bounds.
+    /// </summary>
+    /// <param name="didAutoReset">If <c>true</c>, the player was reset into bounds by the system itself.</param>
+    public delegate void PlayerBackInBoundsDelegate(bool didAutoReset);
 
     /// <summary>
     /// The player bounds module is used for room scale XR applications
@@ -32,14 +37,14 @@ namespace RealityToolkit.Player.Bounds
         Pose LastInBoundsPose { get; }
 
         /// <summary>
-        /// Raised while the <see cref="Rigs.XRPlayerHead"/> is out of bounds.
+        /// Raised while the <see cref="Rigs.IXRPlayerHead"/> is out of bounds.
         /// </summary>
         event PlayerOutOfBoundsDelegate PlayerOutOfBounds;
 
         /// <summary>
-        /// Raised when the <see cref="IPlayerRig.RigCamera"/> is back in bounds.
+        /// Raised when the <see cref="Rigs.IPlayerRig"/> is back in bounds.
         /// </summary>
-        event Action PlayerBackInBounds;
+        event PlayerBackInBoundsDelegate PlayerBackInBounds;
 
         /// <summary>
         /// Force resets the <see cref="Rigs.IPlayerRig"/> into the <see cref="LastInBoundsPose"/>.
@@ -47,19 +52,19 @@ namespace RealityToolkit.Player.Bounds
         void ResetPlayerIntoBounds();
 
         /// <summary>
-        /// The <see cref="Rigs.XRPlayerHead"/> has entered a <see cref="PlayerOutOfBoundsTrigger"/>.
+        /// The <see cref="Rigs.IXRPlayerHead"/> has entered a <see cref="PlayerOutOfBoundsTrigger"/>.
         /// </summary>
         /// <param name="trigger">The <see cref="PlayerOutOfBoundsTrigger"/>.</param>
         void OnTriggerEnter(PlayerOutOfBoundsTrigger trigger);
 
         /// <summary>
-        /// The <see cref="Rigs.XRPlayerHead"/> is staying within a <see cref="PlayerOutOfBoundsTrigger"/>.
+        /// The <see cref="Rigs.IXRPlayerHead"/> is staying within a <see cref="PlayerOutOfBoundsTrigger"/>.
         /// </summary>
         /// <param name="trigger">The <see cref="PlayerOutOfBoundsTrigger"/>.</param>
         void OnTriggerStay(PlayerOutOfBoundsTrigger trigger);
 
         /// <summary>
-        /// The <see cref="Rigs.XRPlayerHead"/> has left a <see cref="PlayerOutOfBoundsTrigger"/>.
+        /// The <see cref="Rigs.IXRPlayerHead"/> has left a <see cref="PlayerOutOfBoundsTrigger"/>.
         /// </summary>
         /// <param name="trigger">The <see cref="PlayerOutOfBoundsTrigger"/>.</param>
         void OnTriggerExit(PlayerOutOfBoundsTrigger trigger);

--- a/Runtime/Bounds/IPlayerBoundsModule.cs
+++ b/Runtime/Bounds/IPlayerBoundsModule.cs
@@ -22,17 +22,17 @@ namespace RealityToolkit.Player.Bounds
     public interface IPlayerBoundsModule : IPlayerServiceModule
     {
         /// <summary>
-        /// Is the active <see cref="IPlayerRig"/> currently considered out of bounds?
+        /// Is the active <see cref="Rigs.IPlayerRig"/> currently considered out of bounds?
         /// </summary>
         bool IsPlayerOutOfBounds { get; }
 
         /// <summary>
-        /// The last saved known <see cref="Pose"/> where the <see cref="IPlayerRig"/> was still in bounds.
+        /// The last saved known <see cref="Pose"/> where the <see cref="Rigs.IPlayerRig"/> was still in bounds.
         /// </summary>
         Pose LastInBoundsPose { get; }
 
         /// <summary>
-        /// Raised while the <see cref="IPlayerRig.RigCamera"/> is out of bounds.
+        /// Raised while the <see cref="Rigs.XRPlayerHead"/> is out of bounds.
         /// </summary>
         event PlayerOutOfBoundsDelegate PlayerOutOfBounds;
 
@@ -42,23 +42,26 @@ namespace RealityToolkit.Player.Bounds
         event Action PlayerBackInBounds;
 
         /// <summary>
-        /// Force resets the <see cref="IPlayerRig"/> into the last known pose
-        /// before it went out of bounds.
+        /// Force resets the <see cref="Rigs.IPlayerRig"/> into the <see cref="LastInBoundsPose"/>.
         /// </summary>
         void ResetPlayerIntoBounds();
 
         /// <summary>
-        /// Raises the <see cref="PlayerOutOfBounds"/> event to subsribed
-        /// <see cref="PlayerOutOfBoundsDelegate"/>s.
+        /// The <see cref="Rigs.XRPlayerHead"/> has entered a <see cref="PlayerOutOfBoundsTrigger"/>.
         /// </summary>
-        /// <param name="severity">A percentage in range <c>[0f, 1f]</c> specifying how far of bounds the player is. Where <c>1f</c> means the player
-        /// is definitely going places it should not be at.</param>
-        /// <param name="returnToBoundsDirection">A <see cref="Vector3"/> specifying the direction the player needs to take to return to into bounds.</param>
-        void RaisePlayerOutOfBounds(float severity, Vector3 returnToBoundsDirection);
+        /// <param name="trigger">The <see cref="PlayerOutOfBoundsTrigger"/>.</param>
+        void OnTriggerEnter(PlayerOutOfBoundsTrigger trigger);
 
         /// <summary>
-        /// Raises the <see cref="PlayerBackInBounds"/> event to subscirbed delegates.
+        /// The <see cref="Rigs.XRPlayerHead"/> is staying within a <see cref="PlayerOutOfBoundsTrigger"/>.
         /// </summary>
-        void RaisePlayerBackInBounds();
+        /// <param name="trigger">The <see cref="PlayerOutOfBoundsTrigger"/>.</param>
+        void OnTriggerStay(PlayerOutOfBoundsTrigger trigger);
+
+        /// <summary>
+        /// The <see cref="Rigs.XRPlayerHead"/> has left a <see cref="PlayerOutOfBoundsTrigger"/>.
+        /// </summary>
+        /// <param name="trigger">The <see cref="PlayerOutOfBoundsTrigger"/>.</param>
+        void OnTriggerExit(PlayerOutOfBoundsTrigger trigger);
     }
 }

--- a/Runtime/Bounds/PlayerBoundsModule.cs
+++ b/Runtime/Bounds/PlayerBoundsModule.cs
@@ -31,6 +31,7 @@ namespace RealityToolkit.Player.Bounds
         private readonly float autoResetTimeout;
         private XRPlayerController playerRig;
         private const float returnToBoundsPoseOffset = .5f;
+        private const float maxSeverity = 1f;
         private PlayerOutOfBoundsTrigger initialTrigger;
         private Vector3 enterPosition;
         private float autoResetTimer;
@@ -68,7 +69,7 @@ namespace RealityToolkit.Player.Bounds
                     autoResetTimer -= Time.deltaTime;
                     if (autoResetTimer <= 0f)
                     {
-                        ResetPlayerIntoBounds();
+                        ResetPlayerIntoBounds(true);
                     }
                 }
 
@@ -81,7 +82,9 @@ namespace RealityToolkit.Player.Bounds
         }
 
         /// <inheritdoc />
-        public void ResetPlayerIntoBounds()
+        public void ResetPlayerIntoBounds() => RaisePlayerBackInBounds(false);
+
+        private void ResetPlayerIntoBounds(bool didAutoReset)
         {
             if (!IsPlayerOutOfBounds)
             {
@@ -95,7 +98,7 @@ namespace RealityToolkit.Player.Bounds
             position -= returnToBoundsPoseOffset * direction;
 
             playerRig.SetPositionAndRotation(position, Quaternion.identity);
-            RaisePlayerBackInBounds();
+            RaisePlayerBackInBounds(didAutoReset);
         }
 
         /// <inheritdoc />
@@ -122,7 +125,7 @@ namespace RealityToolkit.Player.Bounds
 
                 if (IsPlayerOutOfBounds)
                 {
-                    if (!wasAlreadyOutOfBounds)
+                    if (!wasAlreadyOutOfBounds || severity < maxSeverity)
                     {
                         autoResetTimer = autoResetTimeout;
                     }
@@ -137,15 +140,15 @@ namespace RealityToolkit.Player.Bounds
         {
             if (trigger == initialTrigger)
             {
-                RaisePlayerBackInBounds();
+                RaisePlayerBackInBounds(false);
                 initialTrigger = null;
             }
         }
 
-        private void RaisePlayerBackInBounds()
+        private void RaisePlayerBackInBounds(bool didAutoReset)
         {
             IsPlayerOutOfBounds = false;
-            PlayerBackInBounds?.Invoke(false);
+            PlayerBackInBounds?.Invoke(didAutoReset);
         }
     }
 }

--- a/Runtime/Bounds/PlayerBoundsModule.cs
+++ b/Runtime/Bounds/PlayerBoundsModule.cs
@@ -6,7 +6,6 @@ using RealityCollective.ServiceFramework.Definitions.Platforms;
 using RealityCollective.ServiceFramework.Modules;
 using RealityCollective.Utilities.Extensions;
 using RealityToolkit.Player.Rigs;
-using System;
 using UnityEngine;
 
 namespace RealityToolkit.Player.Bounds
@@ -41,7 +40,7 @@ namespace RealityToolkit.Player.Bounds
         public event PlayerOutOfBoundsDelegate PlayerOutOfBounds;
 
         /// <inheritdoc />
-        public event Action PlayerBackInBounds;
+        public event PlayerBackInBoundsDelegate PlayerBackInBounds;
 
         /// <inheritdoc />
         public override void Initialize()
@@ -125,7 +124,7 @@ namespace RealityToolkit.Player.Bounds
         private void RaisePlayerBackInBounds()
         {
             IsPlayerOutOfBounds = false;
-            PlayerBackInBounds?.Invoke();
+            PlayerBackInBounds?.Invoke(false);
         }
     }
 }

--- a/Runtime/Bounds/PlayerBoundsModule.cs
+++ b/Runtime/Bounds/PlayerBoundsModule.cs
@@ -32,8 +32,8 @@ namespace RealityToolkit.Player.Bounds
         private XRPlayerController playerRig;
         private const float returnToBoundsPoseOffset = .5f;
         private const float maxSeverity = 1f;
-        private PlayerOutOfBoundsTrigger initialTrigger;
-        private Vector3 enterPosition;
+        private PlayerOutOfBoundsTrigger currentOutOfBoundsTrigger;
+        private Vector3 boundsExitPosition;
         private float autoResetTimer;
 
         /// <inheritdoc />
@@ -104,21 +104,21 @@ namespace RealityToolkit.Player.Bounds
         /// <inheritdoc />
         public void OnTriggerEnter(PlayerOutOfBoundsTrigger trigger)
         {
-            if (initialTrigger.IsNull())
+            if (currentOutOfBoundsTrigger.IsNull())
             {
-                initialTrigger = trigger;
-                enterPosition = playerRig.Head.Pose.position;
+                currentOutOfBoundsTrigger = trigger;
+                boundsExitPosition = playerRig.Head.Pose.position;
             }
         }
 
         /// <inheritdoc />
         public void OnTriggerStay(PlayerOutOfBoundsTrigger trigger)
         {
-            if (initialTrigger.IsNotNull())
+            if (currentOutOfBoundsTrigger.IsNotNull())
             {
-                var distance = Vector3.Distance(enterPosition, playerRig.Head.Pose.position);
+                var distance = Vector3.Distance(boundsExitPosition, playerRig.Head.Pose.position);
                 var severity = Mathf.Clamp01(distance / maxSeverityDistanceThreshold);
-                var direction = (enterPosition - playerRig.Head.Pose.position).normalized;
+                var direction = (boundsExitPosition - playerRig.Head.Pose.position).normalized;
 
                 var wasAlreadyOutOfBounds = IsPlayerOutOfBounds;
                 IsPlayerOutOfBounds = severity > 0f;
@@ -138,10 +138,10 @@ namespace RealityToolkit.Player.Bounds
         /// <inheritdoc />
         public void OnTriggerExit(PlayerOutOfBoundsTrigger trigger)
         {
-            if (trigger == initialTrigger)
+            if (trigger == currentOutOfBoundsTrigger)
             {
                 RaisePlayerBackInBounds(false);
-                initialTrigger = null;
+                currentOutOfBoundsTrigger = null;
             }
         }
 

--- a/Runtime/Bounds/PlayerBoundsModule.cs
+++ b/Runtime/Bounds/PlayerBoundsModule.cs
@@ -22,19 +22,23 @@ namespace RealityToolkit.Player.Bounds
             : base(name, priority, profile, parentService)
         {
             maxSeverityDistanceThreshold = profile.MaxSeverityDistanceThreshold;
-            autoResetEnabled = profile.AutoResetEnabled;
-            autoResetTimeout = profile.AutoResetTimeout;
+            AutoResetEnabled = profile.AutoResetEnabled;
+            AutoResetTimeout = profile.AutoResetTimeout;
         }
 
         private readonly float maxSeverityDistanceThreshold;
-        private readonly bool autoResetEnabled;
-        private readonly float autoResetTimeout;
         private XRPlayerController playerRig;
         private const float returnToBoundsPoseOffset = .5f;
         private const float maxSeverity = 1f;
         private PlayerOutOfBoundsTrigger currentOutOfBoundsTrigger;
         private Vector3 boundsExitPosition;
         private float autoResetTimer;
+
+        /// <inheritdoc />
+        public bool AutoResetEnabled { get; set; }
+
+        /// <inheritdoc />
+        public float AutoResetTimeout { get; set; }
 
         /// <inheritdoc />
         public bool IsPlayerOutOfBounds { get; private set; }
@@ -64,7 +68,7 @@ namespace RealityToolkit.Player.Bounds
         {
             if (IsPlayerOutOfBounds)
             {
-                if (autoResetEnabled)
+                if (AutoResetEnabled)
                 {
                     autoResetTimer -= Time.deltaTime;
                     if (autoResetTimer <= 0f)
@@ -127,7 +131,7 @@ namespace RealityToolkit.Player.Bounds
                 {
                     if (!wasAlreadyOutOfBounds || severity < maxSeverity)
                     {
-                        autoResetTimer = autoResetTimeout;
+                        autoResetTimer = AutoResetTimeout;
                     }
 
                     PlayerOutOfBounds?.Invoke(severity, direction);

--- a/Runtime/Bounds/PlayerBoundsModuleProfile.cs
+++ b/Runtime/Bounds/PlayerBoundsModuleProfile.cs
@@ -18,5 +18,21 @@ namespace RealityToolkit.Player.Bounds
         /// The distance the head is allowed to move out of bounds before it is considered severely out of bounds.
         /// </summary>
         public float MaxSeverityDistanceThreshold => maxSeverityDistanceThreshold;
+
+        [SerializeField, Tooltip("If set, the player will be reset into bounds if out of bounds for a given period of time.")]
+        private bool autoResetEnabled = true;
+
+        /// <summary>
+        /// If set, the player will be reset into bounds if out of bounds for a given period of time.
+        /// </summary>
+        public bool AutoResetEnabled => autoResetEnabled;
+
+        [SerializeField, Tooltip("Duration in seconds tolerated out of bounds until the player is automatically reset into bounds.")]
+        private float autoResetTimeout = 5f;
+
+        /// <summary>
+        /// Duration in seconds tolerated out of bounds until the player is automatically reset into bounds.
+        /// </summary>
+        public float AutoResetTimeout => autoResetTimeout;
     }
 }

--- a/Runtime/Bounds/PlayerBoundsModuleProfile.cs
+++ b/Runtime/Bounds/PlayerBoundsModuleProfile.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using RealityCollective.ServiceFramework.Definitions;
+using UnityEngine;
+
+namespace RealityToolkit.Player.Bounds
+{
+    /// <summary>
+    /// Configuration profile for the <see cref="PlayerBoundsModule"/>.
+    /// </summary>
+    public class PlayerBoundsModuleProfile : BaseProfile
+    {
+        [SerializeField, Tooltip("The distance the head is allowed to move out of bounds before it is considered severely out of bounds.")]
+        private float maxSeverityDistanceThreshold = .2f;
+
+        /// <summary>
+        /// The distance the head is allowed to move out of bounds before it is considered severely out of bounds.
+        /// </summary>
+        public float MaxSeverityDistanceThreshold => maxSeverityDistanceThreshold;
+    }
+}

--- a/Runtime/Bounds/PlayerBoundsModuleProfile.cs.meta
+++ b/Runtime/Bounds/PlayerBoundsModuleProfile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45845bc60a29897449c67c8bd5176eb6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Bounds/PlayerOutOfBoundsFade.cs
+++ b/Runtime/Bounds/PlayerOutOfBoundsFade.cs
@@ -45,7 +45,7 @@ namespace RealityToolkit.Player.Bounds
             cameraFade.SetFade(severity);
         }
 
-        private void PlayerService_PlayerBackInBounds()
+        private void PlayerService_PlayerBackInBounds(bool didAutoReset)
         {
             cameraFade.SetFade(0f);
         }

--- a/Runtime/Bounds/PlayerOutOfBoundsTrigger.cs
+++ b/Runtime/Bounds/PlayerOutOfBoundsTrigger.cs
@@ -7,9 +7,13 @@ namespace RealityToolkit.Player.Bounds
 {
     /// <summary>
     /// Put this component on a <see cref="GameObject"/> with a <see cref="Collider"/>
-    /// attached to raise <see cref="Interfaces.IPlayerBoundsModule.PlayerOutOfBounds"/>
-    /// and <see cref="Interfaces.IPlayerBoundsModule.PlayerBackInBounds"/> events.
+    /// attached to raise <see cref="IPlayerBoundsModule.PlayerOutOfBounds"/>
+    /// and <see cref="IPlayerBoundsModule.PlayerBackInBounds"/> events.
     /// </summary>
+    /// <remarks>
+    /// This component relies on the <see cref="Rigs.XRPlayerController"/> rig and specifically
+    /// on the <see cref="Rigs.XRPlayerHead"/> being present on that rig.
+    /// </remarks>
     [RequireComponent(typeof(Collider))]
     public class PlayerOutOfBoundsTrigger : MonoBehaviour
     {

--- a/Runtime/Bounds/PlayerOutOfBoundsTrigger.cs
+++ b/Runtime/Bounds/PlayerOutOfBoundsTrigger.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Reality Collective. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using RealityCollective.ServiceFramework.Services;
+using RealityToolkit.Player.Rigs;
 using UnityEngine;
 
 namespace RealityToolkit.Player.Bounds
@@ -11,14 +13,16 @@ namespace RealityToolkit.Player.Bounds
     /// and <see cref="IPlayerBoundsModule.PlayerBackInBounds"/> events.
     /// </summary>
     /// <remarks>
-    /// This component relies on the <see cref="Rigs.XRPlayerController"/> rig and specifically
-    /// on the <see cref="Rigs.XRPlayerHead"/> being present on that rig.
+    /// This component relies on the <see cref="XRPlayerController"/> rig and specifically
+    /// on the <see cref="XRPlayerHead"/> being present on that rig.
     /// </remarks>
     [RequireComponent(typeof(Collider))]
     public class PlayerOutOfBoundsTrigger : MonoBehaviour
     {
         [SerializeField, Tooltip("If set, this trigger will raise player bounds events to the player service.")]
         private bool raiseEvents = true;
+
+        private IPlayerBoundsModule playerBoundsModule;
 
         /// <summary>
         /// If set, this trigger will raise player bounds events to the player service.
@@ -35,10 +39,61 @@ namespace RealityToolkit.Player.Bounds
         }
 
         /// <inheritdoc />
+        protected virtual async void Awake()
+        {
+            await ServiceManager.WaitUntilInitializedAsync();
+
+            if (!ServiceManager.Instance.TryGetService(out playerBoundsModule))
+            {
+                Debug.LogError($"{nameof(PlayerOutOfBoundsTrigger)} requires the {nameof(IPlayerBoundsModule)} to work.", this);
+            }
+        }
+
+        /// <inheritdoc />
         protected virtual void OnEnable()
         {
             var collider = GetComponent<Collider>();
-            collider.isTrigger = true;
+            if (!collider.isTrigger)
+            {
+                collider.isTrigger = true;
+                Debug.LogWarning($"{nameof(PlayerOutOfBoundsTrigger)} requires the attached {nameof(Collider)} to be a trigger and has auto configured it.", this);
+            }
+        }
+
+        /// <inheritdoc />
+        private void OnTriggerEnter(Collider other)
+        {
+            if (playerBoundsModule == null || !RaiseEvents ||
+                !other.TryGetComponent<XRPlayerHead>(out _))
+            {
+                return;
+            }
+
+            playerBoundsModule.OnTriggerEnter(this);
+        }
+
+        /// <inheritdoc />
+        protected virtual void OnTriggerStay(Collider other)
+        {
+            if (playerBoundsModule == null || !RaiseEvents ||
+                !other.TryGetComponent<XRPlayerHead>(out _))
+            {
+                return;
+            }
+
+            playerBoundsModule.OnTriggerStay(this);
+        }
+
+        /// <inheritdoc />
+        protected virtual void OnTriggerExit(Collider other)
+        {
+            if (playerBoundsModule == null || !RaiseEvents ||
+                !other.TryGetComponent<XRPlayerHead>(out _))
+            {
+                return;
+            }
+
+            playerBoundsModule.OnTriggerExit(this);
         }
     }
 }

--- a/Runtime/PlayerService.cs
+++ b/Runtime/PlayerService.cs
@@ -81,10 +81,10 @@ namespace RealityToolkit.Player
         /// <inheritdoc />
         public override void Initialize()
         {
-            var PlayerServiceModules = ServiceManager.Instance.GetServices<IPlayerRigServiceModule>();
-            Debug.Assert(PlayerServiceModules.Count > 0, $"There must be an active {nameof(IPlayerRigServiceModule)}. Please check your {nameof(PlayerServiceProfile)} configuration.");
-            Debug.Assert(PlayerServiceModules.Count < 2, $"There should only ever be one active {nameof(IPlayerRigServiceModule)}. Please check your {nameof(PlayerServiceProfile)} configuration.");
-            PlayerRigServiceModule = PlayerServiceModules[0];
+            var playerServiceModules = ServiceManager.Instance.GetServices<IPlayerRigServiceModule>();
+            Debug.Assert(playerServiceModules.Count > 0, $"There must be an active {nameof(IPlayerRigServiceModule)}. Please check your {nameof(PlayerServiceProfile)} configuration.");
+            Debug.Assert(playerServiceModules.Count < 2, $"There should only ever be one active {nameof(IPlayerRigServiceModule)}. Please check your {nameof(PlayerServiceProfile)} configuration.");
+            PlayerRigServiceModule = playerServiceModules[0];
 
             EnsurePlayerRigSetup();
         }

--- a/Runtime/Rigs/IXRPlayerController.cs
+++ b/Runtime/Rigs/IXRPlayerController.cs
@@ -13,8 +13,13 @@ namespace RealityToolkit.Player.Rigs
         /// <summary>
         /// Controls when gravity begins to take effect.
         /// </summary>
-        /// <seealso cref="RealityToolkit.PlayerService.GravityMode"/>
+        /// <seealso cref="Rigs.GravityMode"/>
         GravityMode GravityMode { get; set; }
+
+        /// <summary>
+        /// The player's head on the <see cref="IXRPlayerController"/>.
+        /// </summary>
+        IXRPlayerHead Head { get; }
 
         /// <summary>
         /// The character's body transform.

--- a/Runtime/Rigs/IXRPlayerHead.cs
+++ b/Runtime/Rigs/IXRPlayerHead.cs
@@ -1,0 +1,20 @@
+﻿using UnityEngine;
+
+namespace RealityToolkit.Player.Rigs
+{
+    /// <summary>
+    /// The player's head on the <see cref="IXRPlayerController"/>.
+    /// </summary>
+    public interface IXRPlayerHead
+    {
+        /// <summary>
+        /// The head's pose in world space.
+        /// </summary>
+        Pose Pose { get; }
+
+        /// <summary>
+        /// The head's radius in meters.
+        /// </summary>
+        float Radius { get; }
+    }
+}

--- a/Runtime/Rigs/IXRPlayerHead.cs.meta
+++ b/Runtime/Rigs/IXRPlayerHead.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cb2f87bd7b9c4a442be23f20acf6d65e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Rigs/XRPlayerController.cs
+++ b/Runtime/Rigs/XRPlayerController.cs
@@ -45,6 +45,11 @@ namespace RealityToolkit.Player.Rigs
         /// <inheritdoc />
         public Transform BodyTransform => bodyTransform;
 
+        /// <summary>
+        /// The head collider is used to offset the body/character collider.
+        /// </summary>
+        public IXRPlayerHead Head => head;
+
         private Vector3 gravityVelocity;
         private Vector3 motionInput;
         private IBodyPoseProviderModule bodyPoseProvider;

--- a/Runtime/Rigs/XRPlayerHead.cs
+++ b/Runtime/Rigs/XRPlayerHead.cs
@@ -1,116 +1,37 @@
 ﻿// Copyright (c) Reality Collective. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using RealityCollective.ServiceFramework.Services;
 using RealityCollective.Utilities.Extensions;
-using RealityToolkit.Player.Bounds;
 using UnityEngine;
 
 namespace RealityToolkit.Player.Rigs
 {
+    /// <summary>
+    /// This component represents the player's head on the <see cref="XRPlayerController"/>.
+    /// </summary>
     [RequireComponent(typeof(Rigidbody))]
     [RequireComponent(typeof(SphereCollider))]
-    public class XRPlayerHead : MonoBehaviour
+    public class XRPlayerHead : MonoBehaviour, IXRPlayerHead
     {
         [SerializeField, Tooltip("The sphere collider wrapping the player's head.")]
         private SphereCollider sphereCollider;
 
-        [SerializeField, Tooltip("The distance the head is allowed to move out of bounds before it is considered severely out of bounds.")]
-        private float maxSeverityDistanceThreshold = .2f;
-
         private XRPlayerController controller;
-        private IPlayerBoundsModule playerBoundsModule;
-        private PlayerOutOfBoundsTrigger initialTrigger;
-        private Vector3 enterPosition;
 
-        /// <summary>
-        /// The radius of the head measured in the object's local space.
-        /// </summary>
+        /// <inheritdoc />
+        public Pose Pose => new Pose(transform.position, transform.rotation);
+
+        /// <inheritdoc />
         public float Radius => sphereCollider.radius;
 
         /// <inheritdoc />
-        protected virtual async void Awake()
+        protected virtual void Awake()
         {
             controller = GetComponentInParent<XRPlayerController>();
             if (controller.IsNull())
             {
                 Debug.LogError($"{nameof(XRPlayerHead)} must be parented to {nameof(XRPlayerController)}.");
             }
-
-            await ServiceManager.WaitUntilInitializedAsync();
-
-            if (ServiceManager.Instance.TryGetService(out playerBoundsModule))
-            {
-                playerBoundsModule.PlayerBackInBounds += PlayerService_PlayerBackInBounds;
-            }
-        }
-
-        /// <inheritdoc />
-        protected virtual void OnDestroy()
-        {
-            if (playerBoundsModule != null)
-            {
-                playerBoundsModule.PlayerBackInBounds -= PlayerService_PlayerBackInBounds;
-            }
-        }
-
-        /// <inheritdoc />
-        private void OnTriggerEnter(Collider other)
-        {
-            if (playerBoundsModule == null)
-            {
-                return;
-            }
-
-            if (initialTrigger.IsNull() &&
-                other.TryGetComponent<PlayerOutOfBoundsTrigger>(out var outOfBoundsTrigger) &&
-                outOfBoundsTrigger.RaiseEvents)
-            {
-                initialTrigger = outOfBoundsTrigger;
-                enterPosition = transform.position;
-            }
-        }
-
-        /// <inheritdoc />
-        protected virtual void OnTriggerStay(Collider other)
-        {
-            if (playerBoundsModule == null)
-            {
-                return;
-            }
-
-            if (initialTrigger.IsNotNull() &&
-                initialTrigger.RaiseEvents)
-            {
-                var distance = Vector3.Distance(enterPosition, transform.position);
-                var severity = Mathf.Clamp01(distance / maxSeverityDistanceThreshold);
-                var direction = (enterPosition - transform.position).normalized;
-
-                playerBoundsModule.RaisePlayerOutOfBounds(severity, direction);
-            }
-        }
-
-        /// <inheritdoc />
-        protected virtual void OnTriggerExit(Collider other)
-        {
-            if (playerBoundsModule == null)
-            {
-                return;
-            }
-
-            if (other.TryGetComponent<PlayerOutOfBoundsTrigger>(out var outOfBoundsTrigger) &&
-                outOfBoundsTrigger == initialTrigger)
-            {
-                playerBoundsModule.RaisePlayerBackInBounds();
-                initialTrigger = null;
-            }
-        }
-
-        protected virtual void PlayerService_PlayerBackInBounds()
-        {
-            // We may have been force moved back into bounds externally, so we
-            // we got to reset internal state.
-            initialTrigger = null;
         }
     }
 }


### PR DESCRIPTION
# Reality Toolkit PR

## What has Changed

### Added

- The `PlayerOutOfBoundsModule` now has its own configuration profile
- The `PlayerOutOfBoundsModule` now supports auto reset. If activated, the player will be reset back into bounds after a given period of time automatically
- Introduced `IXRPlayerHead` interface. The already existing type `XRPlayerHead` is the default implementation of it

### Changed

- Exposed the head on the xr player controller interface
- Moved bounds calculation responsibility out of the xr head component and into the bounds module

### Fixed

- Fixed a couple of doc refs