### PR TITLE
Add support for new input service rig

### DIFF
--- a/Runtime/Rigs/PlayerRig.cs
+++ b/Runtime/Rigs/PlayerRig.cs
@@ -3,6 +3,7 @@
 
 using RealityCollective.ServiceFramework.Services;
 using RealityCollective.Utilities.Extensions;
+using RealityToolkit.Input.Interfaces;
 using UnityEngine;
 
 namespace RealityToolkit.Player.Rigs
@@ -13,7 +14,7 @@ namespace RealityToolkit.Player.Rigs
     [SelectionBase]
     [DisallowMultipleComponent]
     [System.Runtime.InteropServices.Guid("8E0EE4FC-C8A5-4B10-9FCA-EE55B6D421FF")]
-    public class PlayerRig : MonoBehaviour, IPlayerRig
+    public class PlayerRig : MonoBehaviour, IPlayerRig, IInputRig
     {
         [SerializeField, Tooltip("The camera component on the rig.")]
         private Camera rigCamera = null;
@@ -42,6 +43,11 @@ namespace RealityToolkit.Player.Rigs
                 profile.IsRigPersistent)
             {
                 RigTransform.gameObject.DontDestroyOnLoad();
+            }
+
+            if (ServiceManager.Instance.TryGetService<IInputService>(out var inputService))
+            {
+                inputService.InputRig = this;
             }
         }
 

--- a/Runtime/UX/PlayerFootstepSFX.cs
+++ b/Runtime/UX/PlayerFootstepSFX.cs
@@ -11,7 +11,7 @@ namespace RealityToolkit.Player.UX
     /// Produces a footstep sound effect when the player rig moves.
     /// Attach to the <see cref="IPlayerRig"/> <see cref="GameObject"/>.
     /// </summary>
-    [HelpURL("https://www.realitytoolkit.io/docs/category/player")]
+    [HelpURL(RealityToolkitRuntimePreferences.Toolkit_Docs_BaseUrl + "docs/category/player")]
     [RequireComponent(typeof(IPlayerRig))]
     public class PlayerFootstepSFX : MonoBehaviour
 #if RTK_LOCOMOTION

--- a/Runtime/UX/PlayerTrigger.cs
+++ b/Runtime/UX/PlayerTrigger.cs
@@ -10,7 +10,7 @@ namespace RealityToolkit.Player.UX
     /// <summary>
     /// A simple utility component that will raise events as the player enters, leaves or stays within a trigger zone.
     /// </summary>
-    [HelpURL("https://www.realitytoolkit.io/docs/category/player")]
+    [HelpURL(RealityToolkitRuntimePreferences.Toolkit_Docs_BaseUrl + "docs/category/player")]
     [RequireComponent(typeof(Collider))]
     public class PlayerTrigger : MonoBehaviour
     {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/realitycollective"
   },
   "dependencies": {
-    "com.realitytoolkit.core": "1.0.0-pre.56",
+    "com.realitytoolkit.core": "1.0.0-pre.70",
     "com.unity.xr.legacyinputhelpers": "2.1.7"
   },
   "assets": [


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

Adds support for the core modules new `IInputRig` feature and makes the player rig's implement it by default. Giving users a working and non-config out of the box experience when they use core with the player package.